### PR TITLE
Increase compatibility

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: Download atom
+- name: Download atom for Debian OS family
   get_url: url={{ atom_url_deb }} dest={{atom_tmp_deb}}
   tags: ["packages","atom"]
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,5 +4,5 @@
   tags: ["packages","atom"]
 
 - name: Install atom for RedHat OS family
-  yum: name={{atom_tmp_rpm}}
+  package: name={{atom_tmp_rpm}} state=latest
   tags: ["packages","atom"]

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-- name: Download atom
+- name: Download atom for RedHat OS family
   get_url: url={{ atom_url_rpm }} dest={{atom_tmp_rpm}}
   tags: ["packages","atom"]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
  - include: Debian.yml
-   when: ansible_os_family == 'Debian'
+   when: ansible_os_family == 'Debian' and ansible_architecture == 'x86_64'
  - include: RedHat.yml
-   when: ansible_os_family == 'RedHat'
+   when: ansible_os_family == 'RedHat' and ansible_architecture == 'x86_64'


### PR DESCRIPTION
Restrict role run only for x86_84 systems, because default downloads are only for the x86_84.

Change hardcoded `yum` module for RedHat family OS  to general `package` module. `package` module use `yum` or `dnf` command based on target system.
