### PR TITLE
Add 'become' to debian apt tasks

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -4,5 +4,6 @@
   tags: ["packages","atom"]
 
 - name: Install atom for Debian OS family
+  become: yes
   apt: deb={{atom_tmp_deb}}
   tags: ["packages","atom"]


### PR DESCRIPTION
Getting error on running playbook:
TASK [atom : Install atom for Debian OS family] ********************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "dpkg --force-confdef --force-confold -i /tmp/atom.deb failed", "stderr": "dpkg: error: requested operation requires superuser privilege\n", "stdout": "", "stdout_lines": []}
